### PR TITLE
Api svc return val

### DIFF
--- a/src/lib/shared/core-api.service.spec.ts
+++ b/src/lib/shared/core-api.service.spec.ts
@@ -20,10 +20,20 @@ import 'rxjs/add/operator/catch';
 import 'rxjs/add/operator/do';
 import 'rxjs/add/operator/toPromise';
 
+import { AuthService } from './shared/auth.service';
 import { ApiService } from './shared/api.service';
+import { AuthServiceConfig } from './shared/auth-service-config';
 import { CoreApiService } from './core-api.service';
 import { CoreAuthService } from './core-auth.service';
 import { CoreAuthServiceConfig } from './core-auth-service-config';
+
+class AuthServiceConfigMock implements AuthServiceConfig {
+  apiKey: string = '';
+  authToken: string = '';
+  host: string = '//mock.rentdynamics.com';
+  secretKey: string = '';
+  userId: string = '';
+}
 
 class CoreAuthServiceConfigMock implements CoreAuthServiceConfig {
   apiKey: string = '';
@@ -41,6 +51,8 @@ describe('Service: CoreApiService', () => {
       providers: [
         CoreApiService,
         CoreAuthService,
+        AuthService,
+        { provide: AuthServiceConfig, useClass: AuthServiceConfigMock },
         { provide: CoreAuthServiceConfig, useClass: CoreAuthServiceConfigMock },
         { provide: XHRBackend, useClass: MockBackend },
       ]
@@ -51,4 +63,51 @@ describe('Service: CoreApiService', () => {
     inject([CoreApiService], (service: CoreApiService) => {
       expect(service instanceof ApiService).toBe(true);
     }));
+
+  describe('mock backend', () => {
+    let backend: MockBackend;
+    let service: CoreApiService;
+    let fakeResult: any[];
+    let response: Response;
+
+    beforeEach(inject([Http, XHRBackend, AuthService], (http: Http, be: MockBackend, authSvc: AuthService) => {
+      backend = be;
+      service = new CoreApiService(authSvc, http);
+      fakeResult = [{ id: 1 }, { id: 2 }];
+      let options = new ResponseOptions({ status: 200, body: { data: fakeResult } });
+      response = new Response(options);
+    }));
+
+    it('should have expected fake results (then)', async(inject([], () => {
+      backend.connections.subscribe((c: MockConnection) => c.mockRespond(response));
+
+      service.get('/units').toPromise()
+        // .then(() => Promise.reject('deliberate'))
+        .then(results => {
+          expect(results.data.length).toBe(fakeResult.length,
+            'should have expected no. of results');
+        });
+    })));
+
+    it('should have expected fake results (Observable.do)', async(inject([], () => {
+      backend.connections.subscribe((c: MockConnection) => c.mockRespond(response));
+
+      service.put('/units', {}).do(results => {
+        expect(results.data.length).toBe(fakeResult.length,
+          'should have expected number of results');
+      })
+        .toPromise();
+    })));
+
+    it('should be OK returning no results', async(inject([], () => {
+      let resp = new Response(new ResponseOptions({ status: 200, body: { data: [] } }));
+      backend.connections.subscribe((c: MockConnection) => c.mockRespond(resp));
+
+      service.post('/units', {}).do(results => {
+        expect(results.data.length).toBe(0, 'should have no results');
+      })
+        .toPromise();
+    })));
+
+  });
 });

--- a/src/lib/shared/core-api.service.ts
+++ b/src/lib/shared/core-api.service.ts
@@ -14,4 +14,22 @@ export class CoreApiService extends ApiService {
     super(authService, http);
   }
 
+  get(endpoint: string, options: RequestOptionsArgs = {}, responseType: string = 'json'): Observable<any> {
+    return super.get(endpoint, options).map((response: Response) => {
+      return response[responseType]();
+    });
+  }
+
+  put(endpoint: string, body: any, options: RequestOptionsArgs = {}, responseType: string = 'json'): Observable<any> {
+    return super.put(endpoint, body, options).map((response: Response) => {
+      return response[responseType]();
+    });
+  }
+
+  post(endpoint: string, body: any, options: RequestOptionsArgs = {}, responseType: string = 'json'): Observable<any> {
+    return super.post(endpoint, body, options).map((response: Response) => {
+      return response[responseType]();
+    });
+  }
+
 }

--- a/src/lib/shared/rentplus-api.service.spec.ts
+++ b/src/lib/shared/rentplus-api.service.spec.ts
@@ -29,6 +29,14 @@ import { CoreApiService } from './core-api.service';
 import { CoreAuthService } from './core-auth.service';
 import { CoreAuthServiceConfig } from './core-auth-service-config';
 
+class AuthServiceConfigMock implements AuthServiceConfig {
+  apiKey: string = '';
+  authToken: string = '';
+  host: string = '//mock.rentdynamics.com';
+  secretKey: string = '';
+  userId: string = '';
+}
+
 class CoreAuthServiceConfigMock implements AuthServiceConfig {
   apiKey: string = '';
   authToken: string = '';
@@ -53,6 +61,8 @@ describe('Service: RentplusApiService', () => {
       providers: [
         RentplusApiService,
         RentplusAuthService,
+        AuthService,
+        { provide: AuthServiceConfig, useClass: AuthServiceConfigMock },
         { provide: RentplusAuthServiceConfig, useClass: RentplusAuthServiceConfigMock },
         CoreApiService,
         CoreAuthService,
@@ -97,4 +107,52 @@ describe('Service: RentplusApiService', () => {
       //Assert
       expect(config.authToken).toEqual(authToken);
     }));
+
+  describe('mock backend', () => {
+    let backend: MockBackend;
+    let service: RentplusApiService;
+    let fakeResult: any[];
+    let response: Response;
+
+    beforeEach(inject([Http, XHRBackend, AuthService], (http: Http, be: MockBackend, authSvc: AuthService) => {
+      backend = be;
+      service = new RentplusApiService(authSvc, http);
+      fakeResult = [{ id: 1 }, { id: 2 }];
+      let options = new ResponseOptions({ status: 200, body: { data: fakeResult } });
+      response = new Response(options);
+    }));
+
+    it('should have expected fake results (then)', async(inject([], () => {
+      backend.connections.subscribe((c: MockConnection) => c.mockRespond(response));
+
+      service.get('/units').toPromise()
+        // .then(() => Promise.reject('deliberate'))
+        .then(results => {
+          expect(results.data.length).toBe(fakeResult.length,
+            'should have expected no. of results');
+        });
+    })));
+
+    it('should have expected fake results (Observable.do)', async(inject([], () => {
+      backend.connections.subscribe((c: MockConnection) => c.mockRespond(response));
+
+      service.put('/units', {}).do(results => {
+        expect(results.data.length).toBe(fakeResult.length,
+          'should have expected number of results');
+      })
+        .toPromise();
+    })));
+
+    it('should be OK returning no results', async(inject([], () => {
+      let resp = new Response(new ResponseOptions({ status: 200, body: { data: [] } }));
+      backend.connections.subscribe((c: MockConnection) => c.mockRespond(resp));
+
+      service.post('/units', {}).do(results => {
+        expect(results.data.length).toBe(0, 'should have no results');
+      })
+        .toPromise();
+    })));
+
+  });
+
 });

--- a/src/lib/shared/rentplus-api.service.ts
+++ b/src/lib/shared/rentplus-api.service.ts
@@ -14,4 +14,26 @@ export class RentplusApiService extends ApiService {
     super(authService, http);
   }
 
+  get(endpoint: string, options: RequestOptionsArgs = {}, responseType: string = 'json'): Observable<any> {
+    return super.get(endpoint, options).map((response: Response) => {
+      return response[responseType]();
+    });
+  }
+
+  put(endpoint: string, body: any, options: RequestOptionsArgs = {}, responseType: string = 'json'): Observable<any> {
+    return super.put(endpoint, body, options).map((response: Response) => {
+      return response[responseType]();
+    });
+  }
+
+  post(endpoint: string, body: any, options: RequestOptionsArgs = {}, responseType: string = 'json'): Observable<any> {
+    return super.post(endpoint, body, options).map((response: Response) => {
+      return response[responseType]();
+    });
+  }
+
+  postBlob(endpoint: string, body: any, options: RequestOptionsArgs = {}): Observable<any> {
+    return super.post(endpoint, body, options);
+  }
+
 }

--- a/src/lib/shared/shared/api.service.spec.ts
+++ b/src/lib/shared/shared/api.service.spec.ts
@@ -167,7 +167,9 @@ describe('Service: ApiService', () => {
     it('should have expected fake results (then)', async(inject([], () => {
       backend.connections.subscribe((c: MockConnection) => c.mockRespond(response));
 
-      service.get('/units').toPromise()
+      service.get('/units').map((response: Response) => {
+        return response.json();
+      }).toPromise()
         // .then(() => Promise.reject('deliberate'))
         .then(results => {
           expect(results.data.length).toBe(fakeResult.length,
@@ -178,8 +180,9 @@ describe('Service: ApiService', () => {
     it('should have expected fake results (Observable.do)', async(inject([], () => {
       backend.connections.subscribe((c: MockConnection) => c.mockRespond(response));
 
-      service.get('/units')
-        .do(results => {
+      service.get('/units').map((response: Response) => {
+          return response.json();
+        }).do(results => {
           expect(results.data.length).toBe(fakeResult.length,
             'should have expected number of results');
         })
@@ -191,8 +194,9 @@ describe('Service: ApiService', () => {
       let resp = new Response(new ResponseOptions({ status: 200, body: { data: [] } }));
       backend.connections.subscribe((c: MockConnection) => c.mockRespond(resp));
 
-      service.get('/units')
-        .do(results => {
+      service.get('/units').map((response: Response) => {
+          return response.json();
+        }).do(results => {
           expect(results.data.length).toBe(0, 'should have no results');
         })
         .toPromise();

--- a/src/lib/shared/shared/api.service.ts
+++ b/src/lib/shared/shared/api.service.ts
@@ -10,56 +10,42 @@ import { AuthService } from './auth.service';
 @Injectable()
 export class ApiService {
 
-  constructor(public authService: AuthService, public http: Http) {
+  constructor(public authService: AuthService, public http: Http) { }
 
-  }
-
-  get(endpoint: string, options: RequestOptionsArgs = {}, responseType: string = 'json'): Observable<any> {
+  get(endpoint: string, options: RequestOptionsArgs = {}): Observable<any> {
     let url = this.getHost() + endpoint;
     let headers = this.authService.getAuthHeaders(endpoint);
 
     return this.http.get(url, extend({
       headers: headers
-    }, options))
-      .map((response: Response) => {
-        return response[responseType]();
-      });
+    }, options));
   }
 
-  put(endpoint: string, body: any, options: RequestOptionsArgs = {}, responseType: string = 'json'): Observable<any> {
+  put(endpoint: string, body: any, options: RequestOptionsArgs = {}): Observable<any> {
     let url = this.getHost() + endpoint;
     let headers = this.authService.getAuthHeaders(endpoint, body);
 
     return this.http.put(url, body, extend({
       headers: headers
-    }, options))
-      .map((response: Response) => {
-        return response[responseType]();
-      });
+    }, options));
   }
 
-  post(endpoint: string, body: any, options: RequestOptionsArgs = {}, responseType: string = 'json'): Observable<any> {
+  post(endpoint: string, body: any, options: RequestOptionsArgs = {}): Observable<any> {
     let url = this.getHost() + endpoint;
     let headers = this.authService.getAuthHeaders(endpoint, body);
 
     return this.http.post(url, body, extend({
       headers: headers
-    }, options))
-      .map((response: Response) => {
-        return response[responseType]();
-      });
+    }, options));
   }
 
-  postWithoutAuth(endpoint: string, body: any, options: RequestOptionsArgs = {}, responseType: string = 'json'): Observable<any> {
+  postWithoutAuth(endpoint: string, body: any, options: RequestOptionsArgs = {}): Observable<any> {
     let url = this.getHost() + endpoint;
     let headers = this.authService.getAuthHeadersWithoutAuth(endpoint, body);
 
     return this.http.post(url, body, extend({
       headers: headers
-    }, options))
-      .map((response: Response) => {
-        return response[responseType]();
-      });
+    }, options));
   }
 
   delete(endpoint: string, options: RequestOptionsArgs = {}): Observable<any> {

--- a/src/lib/shared/shared/auth.service.spec.ts
+++ b/src/lib/shared/shared/auth.service.spec.ts
@@ -13,7 +13,7 @@ import {
   HttpModule, Http, XHRBackend, Response, ResponseOptions
 } from '@angular/http';
 
-import * as jsSHA from 'jssha';
+declare var jsSHA: jsSHA.jsSHA;
 
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/observable/of';

--- a/src/lib/shared/shared/auth.service.ts
+++ b/src/lib/shared/shared/auth.service.ts
@@ -5,7 +5,7 @@ import { Observable } from 'rxjs/Observable';
 import { Credentials } from './credentials';
 import { AuthServiceConfig } from './auth-service-config';
 
-import * as jsSHA from 'jssha';
+declare var jsSHA: jsSHA.jsSHA;
 
 @Injectable()
 export class AuthService {

--- a/src/lib/shared/text-msg-it-api.service.spec.ts
+++ b/src/lib/shared/text-msg-it-api.service.spec.ts
@@ -29,6 +29,14 @@ import { CoreApiService } from './core-api.service';
 import { CoreAuthService } from './core-auth.service';
 import { CoreAuthServiceConfig } from './core-auth-service-config';
 
+class AuthServiceConfigMock implements AuthServiceConfig {
+  apiKey: string = '';
+  authToken: string = '';
+  host: string = '//mock.rentdynamics.com';
+  secretKey: string = '';
+  userId: string = '';
+}
+
 class CoreAuthServiceConfigMock implements AuthServiceConfig {
   apiKey: string = '';
   authToken: string = '';
@@ -53,6 +61,8 @@ describe('Service: TextMsgItApiService', () => {
       providers: [
         TextMsgItApiService,
         TextMsgItAuthService,
+        AuthService,
+        { provide: AuthServiceConfig, useClass: AuthServiceConfigMock },
         { provide: TextMsgItAuthServiceConfig, useClass: TextMsgItAuthServiceConfigMock },
         CoreApiService,
         CoreAuthService,
@@ -97,4 +107,51 @@ describe('Service: TextMsgItApiService', () => {
       //Assert
       expect(config.authToken).toEqual(authToken);
     }));
+
+  describe('mock backend', () => {
+    let backend: MockBackend;
+    let service: TextMsgItApiService;
+    let fakeResult: any[];
+    let response: Response;
+
+    beforeEach(inject([Http, XHRBackend, AuthService], (http: Http, be: MockBackend, authSvc: AuthService) => {
+      backend = be;
+      service = new TextMsgItApiService(authSvc, http);
+      fakeResult = [{ id: 1 }, { id: 2 }];
+      let options = new ResponseOptions({ status: 200, body: { data: fakeResult } });
+      response = new Response(options);
+    }));
+
+    it('should have expected fake results (then)', async(inject([], () => {
+      backend.connections.subscribe((c: MockConnection) => c.mockRespond(response));
+
+      service.get('/units').toPromise()
+        // .then(() => Promise.reject('deliberate'))
+        .then(results => {
+          expect(results.data.length).toBe(fakeResult.length,
+            'should have expected no. of results');
+        });
+    })));
+
+    it('should have expected fake results (Observable.do)', async(inject([], () => {
+      backend.connections.subscribe((c: MockConnection) => c.mockRespond(response));
+
+      service.put('/units', {}).do(results => {
+        expect(results.data.length).toBe(fakeResult.length,
+          'should have expected number of results');
+      })
+        .toPromise();
+    })));
+
+    it('should be OK returning no results', async(inject([], () => {
+      let resp = new Response(new ResponseOptions({ status: 200, body: { data: [] } }));
+      backend.connections.subscribe((c: MockConnection) => c.mockRespond(resp));
+
+      service.post('/units', {}).do(results => {
+        expect(results.data.length).toBe(0, 'should have no results');
+      })
+        .toPromise();
+    })));
+
+  });
 });

--- a/src/lib/shared/text-msg-it-api.service.ts
+++ b/src/lib/shared/text-msg-it-api.service.ts
@@ -13,4 +13,22 @@ export class TextMsgItApiService extends ApiService {
     super(authService, http);
   }
 
+  get(endpoint: string, options: RequestOptionsArgs = {}, responseType: string = 'json'): Observable<any> {
+    return super.get(endpoint, options).map((response: Response) => {
+      return response[responseType]();
+    });
+  }
+
+  put(endpoint: string, body: any, options: RequestOptionsArgs = {}, responseType: string = 'json'): Observable<any> {
+    return super.put(endpoint, body, options).map((response: Response) => {
+      return response[responseType]();
+    });
+  }
+
+  post(endpoint: string, body: any, options: RequestOptionsArgs = {}, responseType: string = 'json'): Observable<any> {
+    return super.post(endpoint, body, options).map((response: Response) => {
+      return response[responseType]();
+    });
+  }
+
 }


### PR DESCRIPTION
I removed the `.map` function from the api.service, so we can do whatever we want with the response in our implementations of the service. I updated all of our implementations to use the `.map` function, so we don't break any of our existing code.