### PR TITLE
Fix nonce error on cold observable subscription

### DIFF
--- a/src/lib/shared/shared/api.service.spec.ts
+++ b/src/lib/shared/shared/api.service.spec.ts
@@ -91,7 +91,7 @@ describe('Service: ApiService', () => {
       let endpoint = '/endpoint';
       let data = { id: 1 };
       // Act
-      service.postWithoutAuth(endpoint, data);
+      service.postWithoutAuth(endpoint, data).subscribe();
       // Assert
       expect(spy.authSvc.getAuthHeadersWithoutAuth).toHaveBeenCalled();
     }));
@@ -120,7 +120,7 @@ describe('Service: ApiService', () => {
       let endpoint = '/endpoint';
       let body = { id: -1 };
       // Act
-      service.post(endpoint, body);
+      service.post(endpoint, body).subscribe();
       // Assert
       expect(spy.authSvc.getAuthHeaders).toHaveBeenCalled();
       expect(spy.authSvc.getAuthHeaders).toHaveBeenCalledWith('/svc/mock-service/endpoint', { id: -1 });
@@ -271,7 +271,7 @@ describe('Service: ApiService', () => {
             let endpoint = '/endpoint';
             let body = { id: -1 };
             // Act
-            service.post(endpoint, body);
+            service.post(endpoint, body).subscribe();
             // Assert
             expect(spy.authSvc.getAuthHeaders).toHaveBeenCalled();
             expect(spy.authSvc.getAuthHeaders).toHaveBeenCalledWith('/endpoint', { id: -1 });

--- a/src/lib/shared/shared/api.service.ts
+++ b/src/lib/shared/shared/api.service.ts
@@ -1,9 +1,10 @@
 import { Injectable } from '@angular/core';
 import { Http, RequestOptionsArgs, URLSearchParams, Response } from '@angular/http';
-import { BehaviorSubject, Observable, ReplaySubject } from 'rxjs';
+import { BehaviorSubject, Observable, ReplaySubject, of } from 'rxjs';
 
 import { extend } from '../../helpers';
 import { AuthService } from './auth.service';
+import { map, switchMap } from 'rxjs/operators';
 
 
 @Injectable()
@@ -14,51 +15,61 @@ export class ApiService {
   get(endpoint: string, options: RequestOptionsArgs = {}): Observable<any> {
     endpoint = this.getSvcRoute() + endpoint;
     let url = this.getHost() + endpoint;
-    let headers = this.authService.getAuthHeaders(endpoint);
 
-    return this.http.get(url, extend({
-      headers: headers
-    }, options));
+    return of({}).pipe(
+      map(() => this.authService.getAuthHeaders(endpoint)),
+      switchMap(headers => this.http.get(url, extend({
+        headers: headers
+      }, options)))
+    );
   }
 
   put(endpoint: string, body: any, options: RequestOptionsArgs = {}): Observable<any> {
     endpoint = this.getSvcRoute() + endpoint;
     let url = this.getHost() + endpoint;
-    let headers = this.authService.getAuthHeaders(endpoint, body);
 
-    return this.http.put(url, body, extend({
-      headers: headers
-    }, options));
+    return of({}).pipe(
+      map(() => this.authService.getAuthHeaders(endpoint, body)),
+      switchMap(headers => this.http.put(url, body, extend({
+        headers: headers
+      }, options)))
+    );
   }
 
   post(endpoint: string, body: any, options: RequestOptionsArgs = {}): Observable<any> {
     endpoint = this.getSvcRoute() + endpoint;
     let url = this.getHost() + endpoint;
-    let headers = this.authService.getAuthHeaders(endpoint, body);
 
-    return this.http.post(url, body, extend({
-      headers: headers
-    }, options));
+    return of({}).pipe(
+      map(() => this.authService.getAuthHeaders(endpoint, body)),
+      switchMap(headers => this.http.post(url, body, extend({
+        headers: headers
+      }, options)))
+    );
   }
 
   postWithoutAuth(endpoint: string, body: any, options: RequestOptionsArgs = {}): Observable<any> {
     endpoint = this.getSvcRoute() + endpoint;
     let url = this.getHost() + endpoint;
-    let headers = this.authService.getAuthHeadersWithoutAuth(endpoint, body);
 
-    return this.http.post(url, body, extend({
-      headers: headers
-    }, options));
+    return of({}).pipe(
+      map(() => this.authService.getAuthHeadersWithoutAuth(endpoint, body)),
+      switchMap(headers => this.http.post(url, body, extend({
+        headers: headers
+      }, options)))
+    );
   }
 
   delete(endpoint: string, options: RequestOptionsArgs = {}): Observable<any> {
     endpoint = this.getSvcRoute() + endpoint;
     let url = this.getHost() + endpoint;
-    let headers = this.authService.getAuthHeaders(endpoint);
 
-    return this.http.delete(url, extend({
-      headers: headers
-    }, options));
+    return of({}).pipe(
+      map(() => this.authService.getAuthHeaders(endpoint)),
+      switchMap(headers => this.http.delete(url, extend({
+        headers: headers
+      }, options)))
+    );
   }
 
   errorHandler(error) {


### PR DESCRIPTION
Update api service to calculate nonce after observable is hot, instead of immediately. Fixes nonce errors on delayed subscription.

The root cause is a replay attack error in django-rest-framework-simplify that is thrown if a nonce is used with a timestamp larger than a certain interval. If an api call is created but not subscribed to (this happens frequently with async pipes) within a small time window then the request fails with an unhelpful authentication error.