### PR TITLE
fix: Decode pipe characters before nonce calculation

### DIFF
--- a/src/lib/shared/shared/auth.service.ts
+++ b/src/lib/shared/shared/auth.service.ts
@@ -65,7 +65,7 @@ export class AuthService {
 
         https://github.com/Skylude/django-rest-framework-signature/blob/b3d613079137b52f660b9f4f4076cac144d48037/rest_framework_signature/authentication.py#L132
         */
-        var encodedUrl = encodeURI(url).replace('%20', '|');
+        var encodedUrl = encodeURI(url).replace(/%20/g, '|');
 
         var nonceStr = timestamp + encodedUrl;
 

--- a/src/lib/shared/shared/auth.service.ts
+++ b/src/lib/shared/shared/auth.service.ts
@@ -58,7 +58,15 @@ export class AuthService {
     }
 
     getNonce(timestamp: number, url: string, payloadStr?: string) {
-        var encodedUrl = encodeURI(url);
+        /*
+        we need to calculate the nonce on the encoded URL to allow special characters to work
+        in REST calls; HOWEVER, rest-framework-simplify performs a replacement on pipe characters
+        before calculating the nonce on the back-end:
+
+        https://github.com/Skylude/django-rest-framework-signature/blob/b3d613079137b52f660b9f4f4076cac144d48037/rest_framework_signature/authentication.py#L132
+        */
+        var encodedUrl = encodeURI(url).replace('%20', '|');
+
         var nonceStr = timestamp + encodedUrl;
 
         if (typeof payloadStr !== 'undefined') {

--- a/src/lib/shared/shared/auth.service.ts
+++ b/src/lib/shared/shared/auth.service.ts
@@ -65,7 +65,7 @@ export class AuthService {
 
         https://github.com/Skylude/django-rest-framework-signature/blob/b3d613079137b52f660b9f4f4076cac144d48037/rest_framework_signature/authentication.py#L132
         */
-        var encodedUrl = encodeURI(url).replace(/%20/g, '|');
+        var encodedUrl = encodeURI(url).replace(/%7[Cc]/g, '|');
 
         var nonceStr = timestamp + encodedUrl;
 


### PR DESCRIPTION
Because rest-framework-simplify decodes '|' characters before calculating the nonce, '|' characters
must be extracted from the encoded uri before the nonce calculation.